### PR TITLE
Optimize backend logging and restore Google Analytics script

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -19,7 +19,7 @@ from .config import (
 )
 
 # Configure logging
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.WARNING)
 logger = logging.getLogger(__name__)
 
 # Implement MemoryHandler for buffering logs
@@ -89,13 +89,11 @@ async def download_resume() -> FileResponse:
         FileResponse: The resume file
     """
     try:
-        logger.info(f"Looking for resume at: {RESUME_PATH}")
         # Check if file exists before attempting response
         if not RESUME_PATH.exists():
             logger.error(f"Resume file not found at path: {RESUME_PATH}")
             raise HTTPException(status_code=404, detail="Resume file not found.")
         
-        logger.info(f"Serving resume file from: {RESUME_PATH}")
         return FileResponse(
             str(RESUME_PATH),
             media_type="application/pdf",
@@ -106,7 +104,6 @@ async def download_resume() -> FileResponse:
         raise HTTPException(status_code=500, detail="Could not process resume download.")
 
 if __name__ == "__main__":
-    logging.info("Starting the application")
     uvicorn.run(
         "app.main:app",
         host="0.0.0.0",

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -28,6 +28,14 @@
 
     <!-- Favicon -->
     <link rel="shortcut icon" type="image/x-icon" href="{{ url_for('static', path='about/icons/VinayChalluru.ico') }}">
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-3LWVQ0XHJS"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag() { dataLayer.push(arguments); }
+        gtag('js', new Date());
+        gtag('config', 'G-3LWVQ0XHJS');
+    </script>
 </head>
 
 <body>


### PR DESCRIPTION
- Reverted the removal of the Google Analytics (gtag.js) script in `app/templates/profile.html` to keep the user's intended tracking.
- Changed the base logging level in `app/main.py` to `WARNING` to capture only warnings and errors.
- Removed informational logging statements (e.g., `logger.info`) in `app/main.py` to keep the logs clean.
- Retained the `MemoryHandler` with a capacity of 50 to buffer log writes and reduce transactional costs on Azure Files.
- Retained the `@app.api_route` allowing `GET` and `HEAD` requests on the root path `/` to prevent 404 errors from Azure's "Always On" health probes.