### PR TITLE
feat: add clear conversation button to chat widget

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -222,6 +222,16 @@ async def chat(request: Request):
     return response
 
 
+@app.post("/api/chat/clear")
+async def chat_clear(request: Request):
+    session_id = request.cookies.get("session_id")
+    if session_id:
+        await request.app.state.session_store.clear(session_id)
+    response = JSONResponse(content={"cleared": True})
+    response.delete_cookie("session_id")
+    return response
+
+
 @app.post("/api/ingest")
 async def ingest(request: Request):
     from rag.ingestion.pipeline import run_ingest

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -90,12 +90,12 @@
         font-weight: 600; font-size: 0.95rem;
         font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
       }
-      #chat-close, #chat-maximize {
+      #chat-close, #chat-maximize, #chat-clear {
         background: none; border: none; color: #fff;
         cursor: pointer; padding: 2px; display: flex;
         align-items: center; opacity: 0.8;
       }
-      #chat-close:hover, #chat-maximize:hover { opacity: 1; }
+      #chat-close:hover, #chat-maximize:hover, #chat-clear:hover { opacity: 1; }
       #chat-header-actions { display: flex; align-items: center; gap: 8px; }
       #chat-panel.maximized { width: 720px; }
 
@@ -691,6 +691,12 @@
   <div id="chat-header">
     <span>Ask AI about Vinay</span>
     <div id="chat-header-actions">
+      <button id="chat-clear" aria-label="Clear conversation" title="Clear conversation">
+        <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
+          <polyline points="1 4 1 10 7 10"/><polyline points="23 20 23 14 17 14"/>
+          <path d="M20.49 9A9 9 0 0 0 5.64 5.64L1 10m22 4l-4.64 4.36A9 9 0 0 1 3.51 15"/>
+        </svg>
+      </button>
       <button id="chat-maximize" aria-label="Maximize chat">
         <svg id="icon-maximize" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
           <path d="M8 3H5a2 2 0 0 0-2 2v3m18 0V5a2 2 0 0 0-2-2h-3m0 18h3a2 2 0 0 0 2-2v-3M3 16v3a2 2 0 0 0 2 2h3"/>
@@ -722,6 +728,7 @@
   var fab         = document.getElementById('chat-fab');
   var panel       = document.getElementById('chat-panel');
   var closeBtn    = document.getElementById('chat-close');
+  var clearBtn    = document.getElementById('chat-clear');
   var maxBtn      = document.getElementById('chat-maximize');
   var iconMax     = document.getElementById('icon-maximize');
   var iconRestore = document.getElementById('icon-restore');
@@ -729,6 +736,15 @@
   var input       = document.getElementById('chat-input');
   var sendBtn     = document.getElementById('chat-send');
   var callout     = document.getElementById('chat-callout');
+
+  clearBtn.addEventListener('click', function () {
+    fetch('/api/chat/clear', { method: 'POST', credentials: 'include' })
+      .finally(function () {
+        messages.innerHTML = '';
+        input.value = '';
+        input.style.height = 'auto';
+      });
+  });
 
   maxBtn.addEventListener('click', function () {
     var maximized = panel.classList.toggle('maximized');

--- a/rag/session.py
+++ b/rag/session.py
@@ -25,6 +25,11 @@ class SessionStore:
             self._sessions[session_id].extend(messages)
             self._timestamps[session_id] = time.time()
 
+    async def clear(self, session_id: str) -> None:
+        async with self._lock:
+            self._sessions.pop(session_id, None)
+            self._timestamps.pop(session_id, None)
+
     def _purge_expired(self) -> None:
         now = time.time()
         expired = [sid for sid, ts in self._timestamps.items() if now - ts > self._ttl]


### PR DESCRIPTION
- Add clear() method to SessionStore
- Add POST /api/chat/clear endpoint — clears server-side session and deletes the session cookie so the next message starts fresh
- Add refresh icon button in chat header (between maximize and close) that calls the endpoint and wipes the UI messages