### PR TITLE
fix: trigger RAG ingest via CI/CD deploy instead of on every cold start

### DIFF
--- a/.github/workflows/main_vinaychalluru.yml
+++ b/.github/workflows/main_vinaychalluru.yml
@@ -68,3 +68,27 @@ jobs:
           publish-profile: ${{ secrets.AZUREAPPSERVICE_PUBLISHPROFILE_D6C72544E19B43CC94C7E307E46769A0 }}
           scm-do-build-during-deployment: true
           enable-oryx-build: true
+
+      - name: Trigger RAG ingest
+        env:
+          INGEST_SECRET_KEY: ${{ secrets.INGEST_SECRET_KEY }}
+          APP_URL: ${{ steps.deploy-to-function.outputs.webapp-url }}
+        run: |
+          # Retry for a few minutes: right after deploy, the app is cold and
+          # Azure Functions can take a while to finish provisioning the new
+          # deployment package before it accepts requests.
+          for i in $(seq 1 10); do
+            status=$(curl -s -o /tmp/ingest_response.json -w "%{http_code}" \
+              -X POST "$APP_URL/api/ingest" \
+              -H "Authorization: Bearer $INGEST_SECRET_KEY")
+            if [ "$status" = "200" ]; then
+              echo "Ingest succeeded:"
+              cat /tmp/ingest_response.json
+              exit 0
+            fi
+            echo "Attempt $i: ingest returned HTTP $status, retrying in 15s..."
+            sleep 15
+          done
+          echo "Ingest failed after retries. Last response:"
+          cat /tmp/ingest_response.json
+          exit 1

--- a/README.md
+++ b/README.md
@@ -127,21 +127,23 @@ The app will be available at **http://localhost:7071**.
 
 ### 5. Search index
 
-Ingest runs **automatically on the first HTTP request** — Azure Functions lazy-initializes the ASGI app on the first request (not when `func start` launches the host), so the FastAPI lifespan fires then. The app reads the resume PDF and HTML template directly from disk, embeds them, and uploads to Azure AI Search. You'll see log lines like:
+Ingest is **not** triggered automatically — it used to run in the FastAPI lifespan on every cold start, but that meant every visitor after an idle period paid the ~5s+ ingest cost. It's now a manual/CI-triggered step (see [Deployment](#deployment) for how production handles this).
+
+For local dev, trigger it once yourself after `func start` is up:
+
+```bash
+curl -X POST http://localhost:7071/api/ingest \
+  -H "Authorization: Bearer <your-INGEST_SECRET_KEY>"
+```
+
+The app reads the resume PDF and HTML template directly from disk, embeds them, and uploads to Azure AI Search. You'll see log lines like:
 
 ```
 WARNING:rag.ingestion.pipeline:Ingest started
 WARNING:rag.ingestion.pipeline:Ingest complete: {'total_chunks': 87, 'resume_chunks': 42, ...}
 ```
 
-The first request will be slower by ~5s while ingest runs. Subsequent requests are normal. No manual trigger needed.
-
-**Force re-ingest** (e.g. after updating the resume PDF):
-
-```bash
-curl -X POST http://localhost:7071/api/ingest \
-  -H "Authorization: Bearer <your-INGEST_SECRET_KEY>"
-```
+Re-run this any time you update the resume PDF or the HTML template's content.
 
 ### 6. Test the chat
 
@@ -178,4 +180,4 @@ Deployed to Azure Functions via GitHub Actions on push to `main`. The ASGI app i
 
 **After deploying, add all `local.settings.json` keys as Application Settings** in the Azure Portal (Function App → Settings → Environment variables), except `AzureWebJobsStorage` (already set by Azure) and `ENVIRONMENT` (set to `production`).
 
-Ingest runs automatically on every cold start, so no manual trigger is needed after the first deploy. Re-deploy any time the resume PDF or template changes — ingest will rebuild the index on the next startup.
+The GitHub Actions workflow (`.github/workflows/main_vinaychalluru.yml`) triggers ingest automatically once per deploy — after `deploy-to-function` succeeds, it calls `POST /api/ingest` with retries (the app may still be provisioning right after deploy). This requires an `INGEST_SECRET_KEY` GitHub Actions secret matching the value set as an Azure Function App setting. No manual step is needed for normal deploys; re-deploying after a resume PDF or template change rebuilds the index automatically as part of that same deploy.

--- a/app/main.py
+++ b/app/main.py
@@ -42,7 +42,6 @@ async def lifespan(app: FastAPI):
     from rag.vector_store import make_vector_store
     from rag.llm import make_llm
     from rag.session import SessionStore
-    from rag.ingestion.pipeline import run_ingest
 
     app.state.embedder = make_embedder()
     app.state.vector_store = make_vector_store(vector_size=app.state.embedder.dimension)
@@ -51,29 +50,12 @@ async def lifespan(app: FastAPI):
         ttl_seconds=int(os.environ.get("SESSION_TTL_SECONDS", "3600"))
     )
 
-    # Auto-ingest on first request: Azure Functions lazy-initializes the ASGI
-    # app on the first HTTP request, so this lifespan runs then — not when
-    # func start launches the host. The resume PDF and HTML template are read
-    # directly from disk (no HTTP round-trip, no circular dependency). The first
-    # request will be delayed by ingest time (~5s). We swallow errors so a
-    # transient Azure outage does not block the app from starting — the chat
-    # widget will still load; queries just return no results until the next
-    # cold start re-triggers ingest.
-    try:
-        # 60s cap: if Azure AI Search or OpenAI hangs (not errors), the lifespan
-        # yield would never execute and the app would never serve requests.
-        result = await asyncio.wait_for(
-            run_ingest(
-                pdf_path=RESUME_PATH,
-                html_path=_HTML_PATH,
-                embedder=app.state.embedder,
-                store=app.state.vector_store,
-            ),
-            timeout=60.0,
-        )
-    except Exception as exc:
-        logger.error("Startup ingest failed (chat will have no context): %s", exc)
-
+    # Ingestion is NOT run here. Running it on every cold start (Azure Functions
+    # scales to zero and lazy-initializes the ASGI app on the first request after
+    # idle) meant every such visitor paid the full ~5s+ ingest cost. Instead, the
+    # CI/CD workflow (.github/workflows/main_vinaychalluru.yml) calls POST
+    # /api/ingest once, right after each deploy — see that workflow's
+    # "Trigger RAG ingest" step.
     yield
 
 


### PR DESCRIPTION
Azure Functions scales to zero and lazy-initializes the ASGI app on the first HTTP request after idle, so running ingest in the FastAPI lifespan meant every such visitor paid the ~5s+ ingest cost. Ingest now runs once per deploy via a GitHub Actions step that calls POST /api/ingest after the Azure Functions deploy completes, with retries for the app's post-deploy provisioning window.