### PR TITLE
fix: correct Azure functions-action output name in ingest workflow step

### DIFF
--- a/.github/workflows/main_vinaychalluru.yml
+++ b/.github/workflows/main_vinaychalluru.yml
@@ -37,7 +37,7 @@ jobs:
       # Optional: Add step to run tests here
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: python-app
           path: |
@@ -49,11 +49,11 @@ jobs:
     needs: build
     environment:
       name: 'Production'
-      url: ${{ steps.deploy-to-function.outputs.webapp-url }}
+      url: ${{ steps.deploy-to-function.outputs.app-url }}
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: python-app
           path: .
@@ -72,7 +72,7 @@ jobs:
       - name: Trigger RAG ingest
         env:
           INGEST_SECRET_KEY: ${{ secrets.INGEST_SECRET_KEY }}
-          APP_URL: ${{ steps.deploy-to-function.outputs.webapp-url }}
+          APP_URL: ${{ steps.deploy-to-function.outputs.app-url }}
         run: |
           # Retry for a few minutes: right after deploy, the app is cold and
           # Azure Functions can take a while to finish provisioning the new


### PR DESCRIPTION
Azure/functions-action@v1 outputs the deploy URL as `app-url`, not `webapp-url`. The wrong name meant APP_URL was empty, so the ingest curl call got a malformed URL ("/api/ingest" with no host) and failed immediately with exit code 3 instead of retrying.

The `environment.url` field had the same wrong name already, from before the RAG ingest work — but it never caused a failure because it's only used to render the "View deployment" link in GitHub's Environments UI, so an empty value just meant a blank link. It stayed silent until this change reused the same name for `APP_URL`, which curl actually needs a valid URL for — that's the first place the wrong name fed into something functional instead of decorative.

Also bumps upload-artifact/download-artifact to v5 to drop the Node 20 deprecation warning.